### PR TITLE
Fix line number offsets being wrong

### DIFF
--- a/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
+++ b/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
@@ -93,7 +93,7 @@ sub violates {
         $self->get_severity,
       );
 
-      $viol->_set_location([ $ln, 1, 1, $ln, $fn ]);
+      $viol->_set_location([ $ln, 1, 1, $ln, $fn ], $lines[ $ln - 1 ]);
 
       push @hard_violations, $viol;
     } else {
@@ -104,7 +104,7 @@ sub violates {
         $self->get_severity,
       );
 
-      $viol->_set_location([ $ln, 1, 1, $ln, $fn ]);
+      $viol->_set_location([ $ln, 1, 1, $ln, $fn ], $lines[ $ln - 1 ]);
 
       push @soft_violations, $viol;
     }
@@ -123,8 +123,13 @@ sub violates {
 {
   package Perl::Critic::Tics::Violation::VirtualPos;
   BEGIN {require Perl::Critic::Violation; our @ISA = 'Perl::Critic::Violation';}
-  sub _set_location { my ($self, $pos) = @_; $self->{__PACKAGE__}{pos} = $pos; }
+  sub _set_location {
+    my ($self, $pos, $line) = @_;
+    $self->{__PACKAGE__}{pos}  = $pos;
+    $self->{__PACKAGE__}{line} = $line;
+  }
   sub location { $_[0]->{__PACKAGE__}{pos} }
+  sub source   { $_[0]->{__PACKAGE__}{line} }
 }
 
 1;

--- a/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
+++ b/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
@@ -93,7 +93,7 @@ sub violates {
         $self->get_severity,
       );
 
-      $viol->_set_location([ $ln, 1, $ln, 1, $fn ]);
+      $viol->_set_location([ $ln, 1, 1, $ln, $fn ]);
 
       push @hard_violations, $viol;
     } else {
@@ -104,7 +104,7 @@ sub violates {
         $self->get_severity,
       );
 
-      $viol->_set_location([ $ln, 1, $ln, 1, $fn ]);
+      $viol->_set_location([ $ln, 1, 1, $ln, $fn ]);
 
       push @soft_violations, $viol;
     }

--- a/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
+++ b/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
@@ -121,7 +121,8 @@ sub violates {
 }
 
 {
-  package Perl::Critic::Tics::Violation::VirtualPos;
+  package # hide
+    Perl::Critic::Tics::Violation::VirtualPos;
   BEGIN {require Perl::Critic::Violation; our @ISA = 'Perl::Critic::Violation';}
   sub _set_location {
     my ($self, $pos, $line) = @_;

--- a/t/context.t
+++ b/t/context.t
@@ -1,0 +1,42 @@
+
+use strict;
+use warnings;
+
+use Perl::Critic::TestUtils qw(pcritique_with_violations);
+use Test::More;
+
+my $offend = "This line offends the policy maker" x 5;
+
+my $code = <<"EOF";
+my \$line_one = "This is line 1";
+
+=head1 Offending
+
+$offend
+
+=cut
+
+EOF
+
+plan tests => 5;
+
+my $policy = 'Tics::ProhibitLongLines';
+
+my @violations = pcritique_with_violations( $policy, \$code );
+
+is( scalar @violations, 1,
+    '$code is no good (' . @violations . ' violations)' );
+
+my $v = shift @violations;
+
+is( $v->line_number,         5, "violation on line 5" );
+is( $v->logical_line_number, 5, "violation on logical line 5" );
+
+Perl::Critic::Violation::set_format('%m near \'%r\'');
+
+unlike $v->to_string, qr/line 1/,
+  'near context does not show context from line 1';
+
+like $v->to_string, qr/the policy maker/,
+  'near context shows the offending line';
+

--- a/t/line-no.t
+++ b/t/line-no.t
@@ -1,0 +1,28 @@
+
+use strict;
+use warnings;
+
+use Perl::Critic::TestUtils qw(pcritique pcritique_with_violations);
+use Test::More;
+
+my $snippet = '$xy; ';    # 5 chars long
+my $count   = 5;
+my $code = join( "\n", ( ( $snippet x 20 ) x 5 ), ($snippet) x 100 );
+
+plan tests => 11;
+
+my $policy = 'Tics::ProhibitLongLines';
+
+my @violations = pcritique_with_violations( $policy, \$code );
+
+is( scalar @violations, $count, "\$code is no good (" . @violations . " violations)" );
+
+for my $v_no ( 0 .. $#violations ) {
+
+    my $v      = $violations[$v_no];
+    my $v_line = $v_no + 1;
+
+    is( $v->line_number, $v_line,         "violation $v_no on line $v_line" );
+    is( $v->logical_line_number, $v_line, "violation $v_no on logical line $v_line" );
+
+}


### PR DESCRIPTION
This fixes the primary problem addressed in #1, the line of the error being wrong.

However, it does not resolve the issue of the "near" context being useful, and I'll address that in a separate request once I work out how.
