### PR TITLE
fix line numbers in violation

### DIFF
--- a/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
+++ b/lib/Perl/Critic/Policy/Tics/ProhibitLongLines.pm
@@ -93,7 +93,7 @@ sub violates {
         $self->get_severity,
       );
 
-      $viol->_set_location([ $ln, 1, $ln, 1, $fn ]);
+      $viol->_set_location([ $ln, 1, 1, $ln, $fn ]);
 
       push @hard_violations, $viol;
     } else {
@@ -104,7 +104,7 @@ sub violates {
         $self->get_severity,
       );
 
-      $viol->_set_location([ $ln, 1, $ln, 1, $fn ]);
+      $viol->_set_location([ $ln, 1, 1, $ln, $fn ]);
 
       push @soft_violations, $viol;
     }


### PR DESCRIPTION
This is the sort order of array indices used for a violation location: (Violation.pm)

Readonly::Scalar my $LOCATION_LINE_NUMBER               => 0;
Readonly::Scalar my $LOCATION_COLUMN_NUMBER             => 1;
Readonly::Scalar my $LOCATION_VISUAL_COLUMN_NUMBER      => 2;
Readonly::Scalar my $LOCATION_LOGICAL_LINE_NUMBER       => 3;
Readonly::Scalar my $LOCATION_LOGICAL_FILENAME          => 4;

ATM all violations are reported to be on line 1.
